### PR TITLE
Add Spectrum AAAI2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ The model is trained on fully-supervised semantic segmentation datasets with pix
 51. <span id = "1003">**[MaskCLIP++]**</span> | **ArXiv'25.03** | MaskCLIP++: High-Quality Mask Tuning Matters for Open-Vocabulary Segmentation | [`[pdf]`](https://arxiv.org/pdf/2412.11464) | [`[code]`](https://github.com/HVision-NKU/MaskCLIPpp)
 52. <span id = "1003">**[OVSNet]**</span> | **ICCV'25** | Stepping Out of Similar Semantic Space for Open-Vocabulary Segmentation | [`[pdf]`](https://www.arxiv.org/pdf/2506.16058)
 53. <span id = "1003">**[R-SC-CLIPSelf]**</span> | **ICLR'25** | Refining CLIP's Spatial Awareness: A Visual-Centric Perspective | [`[pdf]`](https://arxiv.org/pdf/2504.02328)
-54. <span id = "1003">**[OpenWorldSAM]**</span> | **NeurIPS'25 Spotlight** | OpenWorldSAM: Extending SAM2 for Universal Image Segmentation with Language Prompts | [`[pdf]`](https://arxiv.org/pdf/2507.05427) 
+54. <span id = "1003">**[OpenWorldSAM]**</span> | **NeurIPS'25 Spotlight** | OpenWorldSAM: Extending SAM2 for Universal Image Segmentation with Language Prompts | [`[pdf]`](https://arxiv.org/pdf/2507.05427)
+55. <span id = "1003">**[Spectrum]**</span> | **AAAI'26** | Learning 3D Texture-Aware Representations for Parsing Diverse Human Clothing and Body Parts | [`[pdf]`](https://arxiv.org/abs/2508.06032) | [`[project]`](https://s-pectrum.github.io/)
 
 
 


### PR DESCRIPTION
Hello! Thanks for maintaining this awesome repository! I’d like to suggest adding Spectrum, our new method for fine-grained human parsing (body parts + clothing) with instance-level grouping.

Unlike many open-vocabulary segmentation approaches that collapse humans into a single “person” category, Spectrum produces semantic masks for every visible body part and clothing category (and ignores standalone garments / irrelevant objects). We repurpose an Image-to-Texture (I2Tx) diffusion model (fine-tuned from T2I on 3D human texture maps) to get features that align better with detailed parts and diverse clothing, then use prompt-guided grounding for semantically valid masks.

🌐 Website: https://s-pectrum.github.io/
🧠 Paper: https://arxiv.org/abs/2508.06032 (AAAI 2026)

Thanks in advance for considering it!